### PR TITLE
feat: WhisperX 3.3.4 업그레이드 및 설정 최적화

### DIFF
--- a/ai/stt-service/app/core/config.py
+++ b/ai/stt-service/app/core/config.py
@@ -13,6 +13,10 @@ class Settings(BaseSettings):
     API_V1_STR: str = "/api/v1"
     PROJECT_NAME: str = "STT Service"
     
+    # 오디오 관련 상수
+    SAMPLE_RATE: int = 16000  # 오디오 샘플링 레이트 (Hz)
+    DEFAULT_BUFFER_SIZE: int = 960000  # 기본 오디오 버퍼 크기 (bytes)
+    
     # WhisperX 모델 설정
     WHISPER_MODEL: str = "turbo"  # 사용할 모델 (tiny, base, small, medium, large, large-v3)
     DEVICE: str = "cuda"  # 사용할 장치 ("cuda" 또는 "cpu")
@@ -42,7 +46,7 @@ class Settings(BaseSettings):
     
     # 시스템 리소스 제한
     MAX_WORKERS: int = 4  # 병렬 작업자 수
-    MAX_AUDIO_BUFFER_MB: int = 30  # 최대 오디오 버퍼 크기(MB)
+    MAX_AUDIO_BUFFER_MB: int = 15  # 최대 오디오 버퍼 크기(MB) - 30초 분량
     
     # 시나리오별 VAD 파라미터 (음성 감지 민감도)
     SCENARIO_VAD_PARAMS: Dict[str, Dict[str, Any]] = {

--- a/ai/stt-service/app/services/stt_service.py
+++ b/ai/stt-service/app/services/stt_service.py
@@ -12,7 +12,6 @@ from app.core.config import settings
 from app.core.logging import logger
 from app.core.models import STTResponse, TimestampedWord
 
-
 class STTProcessor:
     """WhisperX 모델을 사용한 STT 처리 클래스"""
     
@@ -174,7 +173,7 @@ class STTProcessor:
             # 오디오 로드
             audio = whisperx.load_audio(temp_file_path)
             
-            logger.info(f"오디오 로드 완료. 오디오 길이: {len(audio) / whisperx.audio.SAMPLE_RATE:.2f}초")
+            logger.info(f"오디오 로드 완료. 오디오 길이: {len(audio) / settings.SAMPLE_RATE:.2f}초")
             
             # transcribe 매개변수 준비
             transcribe_params = self._prepare_transcribe_params(language, scenario, return_timestamps)
@@ -196,7 +195,7 @@ class STTProcessor:
                 words_list = self._extract_word_timestamps(segments_list)
             
             # 오디오 길이 계산
-            audio_duration = len(audio) / whisperx.audio.SAMPLE_RATE
+            audio_duration = len(audio) / settings.SAMPLE_RATE
             
             processing_time = time.time() - start_time
             logger.info(f"오디오 처리 완료 (소요 시간: {processing_time:.2f}초, 오디오 길이: {audio_duration:.2f}초)")

--- a/ai/stt-service/build_ctranslate2_cuda.sh
+++ b/ai/stt-service/build_ctranslate2_cuda.sh
@@ -51,4 +51,3 @@ pip install dist/*.whl
 cd $CURRENT_DIR
 
 echo "CTranslate2가 CUDA 지원으로 성공적으로 빌드되었습니다."
-echo "이제 'python -m uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload' 명령으로 서버를 실행하세요." 

--- a/ai/stt-service/requirements.txt
+++ b/ai/stt-service/requirements.txt
@@ -8,8 +8,8 @@ websockets==12.0            # WebSocket 지원
 httpx==0.28.1
 
 # WhisperX - 음성 인식 라이브러리 및 의존성
-whisperx==3.1.1  # numpy 1.26.4와 호환되는 버전
-pyannote.audio==3.1.1
+whisperx==3.3.4  # numpy 1.26.4와 호환되는 버전
+pyannote.audio
 transformers
 setuptools>=65
 faster-whisper==1.1.1
@@ -18,9 +18,10 @@ faster-whisper==1.1.1
 pydantic==2.6.4
 pydantic-settings==2.2.1  # 설정 관리
 python-dotenv==1.0.1      # 환경 변수 로드
-numpy==1.26.4             # 오디오 처리
+numpy>=2.0.0              # 오디오 처리
 
 # PyTorch는 미리 설치된 버전 사용
 # torch==2.7.0
 # torchaudio==2.7.0
 # torchvision==0.22.0 
+# ctranslate2<4.5.0

--- a/ai/stt-service/test/web/index.html
+++ b/ai/stt-service/test/web/index.html
@@ -456,7 +456,7 @@
                 this.audioBuffer = [];
                 this.audioBufferDuration = 0;
                 this.bufferStartTime = null;
-                this.bufferDuration = 60; // 60초
+                this.bufferDuration = 30; // 60초
                 this.totalAudioSent = 0;
                 this.totalAudioReceived = 0;
                 


### PR DESCRIPTION
### 📋 변경 사항 요약
- **WhisperX 버전 업그레이드**: 3.1.1 → 3.3.4
- **API 호환성 수정**: `whisperx.audio.SAMPLE_RATE` 제거에 따른 대응
- **상수 중앙화**: 하드코딩된 오디오 관련 상수를 `config.py`로 이동
- **오디오 버퍼 최적화**: 60초 → 30초 분량으로 단축

### 🔧 주요 수정 내용

#### 1. API 호환성 문제 해결
- **문제**: WhisperX 3.3.4에서 `whisperx.audio` 모듈 제거
- **해결**: `SAMPLE_RATE = 16000` 상수를 `config.py`에서 중앙 관리
- **영향 파일**: `stt_service.py`, `websocket_service.py`

#### 2. 설정 중앙화
```python
# Before (하드코딩)
SAMPLE_RATE = 16000
buffer_threshold = min(960000, settings.MAX_AUDIO_BUFFER_MB * 1024 * 1024)

# After (config 관리)
SAMPLE_RATE: int = 16000  # config.py
DEFAULT_BUFFER_SIZE: int = 960000  # config.py
buffer_threshold = min(settings.DEFAULT_BUFFER_SIZE, settings.MAX_AUDIO_BUFFER_MB * 1024 * 1024)
```

#### 3. 오디오 처리 최적화
- **MAX_AUDIO_BUFFER_MB**: 30MB → 15MB
- **처리 분량**: 60초 → 30초 오디오
- **메모리 효율성**: 향상된 버퍼 관리

### 📁 수정된 파일
- `app/core/config.py`: 오디오 상수 추가 및 버퍼 크기 조정
- `app/services/stt_service.py`: `settings.SAMPLE_RATE` 사용으로 변경
- `app/services/websocket_service.py`: config 기반 버퍼 관리로 변경

### ✅ 테스트 결과
- [x] 서비스 정상 시작 확인
- [x] WhisperX 모델 로딩 성공
- [x] 오디오 처리 정상 동작
- [x] 30초 버퍼 제한 적용 확인

### 🔍 호환성 확인
- **Python**: 3.10+ ✅
- **CUDA**: 지원 ✅
- **WhisperX**: 3.3.4 ✅
- **기존 API**: 변경사항 없음 ✅

### 📈 성능 개선
- **메모리 사용량**: 50% 감소 (30MB → 15MB 버퍼)
- **처리 지연**: 단축된 버퍼로 더 빠른 응답
- **안정성**: 최신 라이브러리 버전으로 버그 수정

### 🔗 관련 이슈
- 해결: WhisperX 3.3.4 호환성 문제
- 개선: 오디오 버퍼 최적화

---

## ✅ 체크리스트

### 코드 품질
- [x] 코드 리뷰 완료
- [x] 테스트 통과
- [x] 문서 업데이트
- [x] 버전 호환성 확인

### 기능 검증
- [x] STT 서비스 정상 동작
- [x] WebSocket 연결 안정성
- [x] 오디오 처리 성능
- [x] 에러 핸들링

---

## 🔄 배포 가이드

### 1. 의존성 업데이트
```bash
pip install -r requirements.txt
```

### 2. 서비스 재시작
```bash
# 기존 서비스 중지
pkill -f "python app/main.py"

# 새 버전 시작
source venv/bin/activate
PYTHONPATH=. python app/main.py
```

### 3. 헬스체크
```bash
curl http://localhost:8000/health
```
